### PR TITLE
fix: margins and text in sddm theme

### DIFF
--- a/sddm/Login.qml
+++ b/sddm/Login.qml
@@ -162,7 +162,7 @@ Item {
             // Greeting Label
             Label {
                 id: greetingLabel
-                text: hours < 12 ? "Good Morning" : hours < 18 ? "Good afternoon" : "Good evening"
+                text: hours < 12 ? "Good Morning," : hours < 18 ? "Good Afternoon," : "Good Evening,"
                 color: "#fff"
                 style: softwareRendering ? Text.Outline : Text.Normal
                 styleColor: softwareRendering ? ColorScope.backgroundColor : "transparent" //no outline, doesn't matter
@@ -209,6 +209,7 @@ Item {
                 
                 Layout.fillWidth: true
                 Layout.topMargin: 20
+                Layout.rightMargin: 30
 
                 Input {
                     id: passwordBox
@@ -325,7 +326,7 @@ Item {
             
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
-        //anchors.bottomMargin: height / 2
+        anchors.bottomMargin: height / 2
     }
 
 }

--- a/sddm/Main.qml
+++ b/sddm/Main.qml
@@ -115,8 +115,8 @@ PlasmaCore.ColorScope {
         Clock {
             id: clock
             visible: true
-            x: parent.width - width - 10
-            y: parent.height - height - 10
+            x: parent.width - width - 30
+            y: parent.height - height - 30
         }
 
 


### PR DESCRIPTION
First off I want to say thank you for making this, one of the best KDE themes I've ever seen!

I have made some customizations to the SDDM theme for my own config, and I think some of the changes I made makes sense to bring upstream, so that's what this PR is. Below are some screenshots showing it in 1080p and 1440p. I also took screenshots of what the theme looks like as of 8d7fe15 and layered it on top of the version in my PR as a difference layer so it's easier to see what has changed.

my tweaks `1920x1080`
![03-after-1920x1080](https://github.com/EliverLara/Andromeda-KDE/assets/13402525/3e262520-5b30-4631-a1da-e213bfc2506c)
my tweaks `2560x1440`
![04-after-2560x1440](https://github.com/EliverLara/Andromeda-KDE/assets/13402525/9b9745c3-0d8d-4872-b204-28b42616e831)

diff `1920x1080`
![05-diff-1920x1080](https://github.com/EliverLara/Andromeda-KDE/assets/13402525/4cc2e3d6-9b18-4da4-aeaf-17ea77977544)
diff `2560x1440`
![06-diff-2560x1440](https://github.com/EliverLara/Andromeda-KDE/assets/13402525/610cad4c-8ede-44de-b0de-262afde1e771)

Let me know what you think and if anything should change. I'm very much a noob at Qt though just so you know. Thanks again for this lovely KDE theme!